### PR TITLE
Bump commons-io:commons-io from 2.6 to 2.14.0 in /spring-jdbc

### DIFF
--- a/spring-jdbc/pom.xml
+++ b/spring-jdbc/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.14.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps commons-io:commons-io from 2.6 to 2.14.0.

---
updated-dependencies:
- dependency-name: commons-io:commons-io dependency-type: direct:production ...