### PR TITLE
Bump httpclient from 4.5.7 to 4.5.13 in /spring-rest-validation

### DIFF
--- a/spring-rest-validation/pom.xml
+++ b/spring-rest-validation/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.7</version>
+            <version>4.5.13</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Bumps httpclient from 4.5.7 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient dependency-type: direct:development ...